### PR TITLE
Disable Neo4j authentication for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ ollama pull mxbai-embed-large
 
 ### 3. Access Services
 - **Qdrant Web UI**: http://localhost:6333/dashboard
-- **Neo4j Browser**: http://localhost:7474 (neo4j/contextmemory)
+- **Neo4j Browser**: http://localhost:7474 (no authentication required)
 - **Grafana Dashboard**: http://localhost:3000 (admin/contextmemory)
 - **Prometheus**: http://localhost:9090
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - neo4j_import:/var/lib/neo4j/import
       - neo4j_plugins:/plugins
     environment:
-      - NEO4J_AUTH=${NEO4J_USERNAME:-neo4j}/${NEO4J_PASSWORD:-contextmemory}
+      - NEO4J_AUTH=none
       - NEO4J_PLUGINS=apoc
       - NEO4J_dbms_security_procedures_unrestricted=apoc.*
       - NEO4J_dbms_security_procedures_allowlist=apoc.*

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -209,7 +209,7 @@ Test scripts respect the following environment variables:
 ### Service Credentials
 
 Test scripts use the default POC credentials:
-- Neo4j: `neo4j` / `contextmemory`
+- Neo4j: No authentication required (disabled for local development)
 - Grafana: `admin` / `contextmemory`
 
 ## Security Considerations

--- a/scripts/validate-services.sh
+++ b/scripts/validate-services.sh
@@ -96,7 +96,7 @@ validate_neo4j() {
     log_info "Validating Neo4j functionality..."
     
     # Test basic authentication and connectivity
-    if curl -s --max-time $TIMEOUT -u "$NEO4J_USER:$NEO4J_PASS" \
+    if curl -s --max-time $TIMEOUT \
         -H "Content-Type: application/json" \
         -X POST "http://localhost:7474/db/neo4j/tx/commit" \
         -d '{"statements":[{"statement":"RETURN 1 as test"}]}' | grep -q "test"; then
@@ -107,7 +107,7 @@ validate_neo4j() {
     fi
     
     # Test APOC availability
-    if curl -s --max-time $TIMEOUT -u "$NEO4J_USER:$NEO4J_PASS" \
+    if curl -s --max-time $TIMEOUT \
         -H "Content-Type: application/json" \
         -X POST "http://localhost:7474/db/neo4j/tx/commit" \
         -d '{"statements":[{"statement":"CALL apoc.help(\"apoc\") YIELD name RETURN count(name) as apoc_procedures"}]}' | grep -q "apoc_procedures"; then

--- a/scripts/validate-services.sh
+++ b/scripts/validate-services.sh
@@ -14,8 +14,7 @@ NC='\033[0m' # No Color
 
 # Configuration
 TIMEOUT=15
-NEO4J_USER="neo4j"
-NEO4J_PASS="contextmemory"
+# Neo4j authentication disabled for local development
 GRAFANA_USER="admin"
 GRAFANA_PASS="contextmemory"
 
@@ -99,7 +98,7 @@ validate_neo4j() {
     # Test basic authentication and connectivity
     if curl -s --max-time $TIMEOUT -u "$NEO4J_USER:$NEO4J_PASS" \
         -H "Content-Type: application/json" \
-        -X POST "http://localhost:7474/db/data/transaction/commit" \
+        -X POST "http://localhost:7474/db/neo4j/tx/commit" \
         -d '{"statements":[{"statement":"RETURN 1 as test"}]}' | grep -q "test"; then
         log_success "Neo4j authentication and basic queries working"
     else
@@ -110,7 +109,7 @@ validate_neo4j() {
     # Test APOC availability
     if curl -s --max-time $TIMEOUT -u "$NEO4J_USER:$NEO4J_PASS" \
         -H "Content-Type: application/json" \
-        -X POST "http://localhost:7474/db/data/transaction/commit" \
+        -X POST "http://localhost:7474/db/neo4j/tx/commit" \
         -d '{"statements":[{"statement":"CALL apoc.help(\"apoc\") YIELD name RETURN count(name) as apoc_procedures"}]}' | grep -q "apoc_procedures"; then
         log_success "Neo4j APOC procedures are available"
     else
@@ -122,9 +121,9 @@ validate_neo4j() {
     local test_label="ValidationTest$(date +%s)"
     
     # Create test node
-    if curl -s --max-time $TIMEOUT -u "$NEO4J_USER:$NEO4J_PASS" \
+    if curl -s --max-time $TIMEOUT \
         -H "Content-Type: application/json" \
-        -X POST "http://localhost:7474/db/data/transaction/commit" \
+        -X POST "http://localhost:7474/db/neo4j/tx/commit" \
         -d "{\"statements\":[{\"statement\":\"CREATE (n:$test_label {name: 'test', timestamp: timestamp()}) RETURN n.name as name\"}]}" | grep -q "test"; then
         log_success "Neo4j node creation successful"
     else
@@ -133,9 +132,9 @@ validate_neo4j() {
     fi
     
     # Query test node
-    if curl -s --max-time $TIMEOUT -u "$NEO4J_USER:$NEO4J_PASS" \
+    if curl -s --max-time $TIMEOUT \
         -H "Content-Type: application/json" \
-        -X POST "http://localhost:7474/db/data/transaction/commit" \
+        -X POST "http://localhost:7474/db/neo4j/tx/commit" \
         -d "{\"statements\":[{\"statement\":\"MATCH (n:$test_label) RETURN n.name as name\"}]}" | grep -q "test"; then
         log_success "Neo4j node querying working"
     else
@@ -143,9 +142,9 @@ validate_neo4j() {
     fi
     
     # Cleanup test nodes
-    curl -s --max-time $TIMEOUT -u "$NEO4J_USER:$NEO4J_PASS" \
+    curl -s --max-time $TIMEOUT \
         -H "Content-Type: application/json" \
-        -X POST "http://localhost:7474/db/data/transaction/commit" \
+        -X POST "http://localhost:7474/db/neo4j/tx/commit" \
         -d "{\"statements\":[{\"statement\":\"MATCH (n:$test_label) DELETE n\"}]}" > /dev/null
     
     # Test metrics endpoint


### PR DESCRIPTION
## Summary
Fixes #26 - Disables Neo4j authentication for local development environment

## Changes Made
- Set `NEO4J_AUTH=none` in docker-compose.yml to disable authentication
- Remove credential parameters from validation script curl commands  
- Update Neo4j API endpoints to use correct `/db/neo4j/tx/commit` path
- Update README.md to reflect no authentication required for Neo4j Browser
- Update testing documentation to remove Neo4j credential references

## Validation Completed
- [x] Neo4j web interface at http://localhost:7474 loads without authentication prompt
- [x] Neo4j API operations work without credentials (tested create/delete operations)
- [x] All existing functionality continues to work (scripts updated)
- [x] Documentation updated to remove Neo4j credential references
- [x] Testing scripts work with disabled authentication

## Test Plan
- [x] Start services with `docker-compose up -d`
- [x] Verify Neo4j browser accessible without credentials at http://localhost:7474
- [x] Test Neo4j API operations without authentication
- [x] Run validation scripts to ensure functionality maintained
- [x] Verify documentation updates are accurate

🤖 Generated with [Claude Code](https://claude.ai/code)