### PR TITLE
Disable Grafana authentication for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ ollama pull mxbai-embed-large
 ### 3. Access Services
 - **Qdrant Web UI**: http://localhost:6333/dashboard
 - **Neo4j Browser**: http://localhost:7474 (no authentication required)
-- **Grafana Dashboard**: http://localhost:3000 (admin/contextmemory)
+- **Grafana Dashboard**: http://localhost:3000 (no authentication required)
 - **Prometheus**: http://localhost:9090
 
 ### 4. Configure Your Project

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,9 @@ services:
       - ./config/grafana/dashboards:/etc/grafana/provisioning/dashboards
       - ./config/grafana/datasources:/etc/grafana/provisioning/datasources
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-contextmemory}
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      # GF_SECURITY_ADMIN_PASSWORD disabled for local development
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
       interval: 30s

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -210,7 +210,7 @@ Test scripts respect the following environment variables:
 
 Test scripts use the default POC credentials:
 - Neo4j: No authentication required (disabled for local development)
-- Grafana: `admin` / `contextmemory`
+- Grafana: No authentication required (anonymous access enabled)
 
 ## Security Considerations
 

--- a/scripts/validate-services.sh
+++ b/scripts/validate-services.sh
@@ -15,8 +15,7 @@ NC='\033[0m' # No Color
 # Configuration
 TIMEOUT=15
 # Neo4j authentication disabled for local development
-GRAFANA_USER="admin"
-GRAFANA_PASS="contextmemory"
+# Grafana authentication disabled for local development (anonymous access enabled)
 
 log_info() {
     echo -e "${BLUE}ℹ️  $1${NC}"
@@ -189,17 +188,17 @@ validate_prometheus() {
 validate_grafana() {
     log_info "Validating Grafana functionality..."
     
-    # Test authentication
-    if curl -s --max-time $TIMEOUT -u "$GRAFANA_USER:$GRAFANA_PASS" \
-        "http://localhost:3000/api/user" | grep -q "admin"; then
-        log_success "Grafana authentication working"
+    # Test anonymous access
+    if curl -s --max-time $TIMEOUT \
+        "http://localhost:3000/api/org" | grep -q "Main Org"; then
+        log_success "Grafana anonymous access working"
     else
-        log_error "Grafana authentication failed"
+        log_error "Grafana anonymous access failed"
         return 1
     fi
     
     # Test data sources
-    if curl -s --max-time $TIMEOUT -u "$GRAFANA_USER:$GRAFANA_PASS" \
+    if curl -s --max-time $TIMEOUT \
         "http://localhost:3000/api/datasources" | grep -q "prometheus"; then
         log_success "Grafana data sources configured"
     else
@@ -207,7 +206,7 @@ validate_grafana() {
     fi
     
     # Test dashboard API
-    if curl -s --max-time $TIMEOUT -u "$GRAFANA_USER:$GRAFANA_PASS" \
+    if curl -s --max-time $TIMEOUT \
         "http://localhost:3000/api/search" > /dev/null; then
         log_success "Grafana dashboard API accessible"
     else


### PR DESCRIPTION
## Summary
Fixes #27 - Disables Grafana authentication for local development environment by enabling anonymous access

## Changes Made
- Enable anonymous access with `GF_AUTH_ANONYMOUS_ENABLED=true`
- Set anonymous users as Admin with `GF_AUTH_ANONYMOUS_ORG_ROLE=Admin`  
- Remove `GF_SECURITY_ADMIN_PASSWORD` for local development
- Update validation scripts to work with anonymous access instead of credentials
- Update README.md and testing documentation to reflect no authentication required

## Validation Completed
- [x] Grafana web interface at http://localhost:3000 loads without authentication prompt
- [x] Anonymous users have admin access to view/edit dashboards
- [x] All existing dashboards and data sources continue to work (API tested)
- [x] Documentation updated to remove Grafana credential references  
- [x] Validation scripts updated to work with anonymous access

## Test Plan
- [x] Start services with `docker-compose up -d`
- [x] Verify Grafana web interface accessible without credentials at http://localhost:3000
- [x] Test Grafana API endpoints work with anonymous access
- [x] Verify dashboards are accessible via `/api/search` endpoint
- [x] Run validation scripts to ensure functionality maintained
- [x] Verify documentation updates are accurate

## API Testing Results
```bash
# Anonymous access working
curl http://localhost:3000/api/org -> {"id":1,"name":"Main Org.",...}

# Dashboard API accessible  
curl http://localhost:3000/api/search -> [{"id":1,"title":"Context Memory Store Dashboard",...}]
```

🤖 Generated with [Claude Code](https://claude.ai/code)