### PR TITLE
Parameterize Neo4j memory settings via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,14 @@
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=contextmemory
 
+# Neo4j Memory Configuration
+# Initial heap size for Neo4j JVM (default: 512m)
+NEO4J_INITIAL_HEAP_SIZE=512m
+# Maximum heap size for Neo4j JVM (default: 1g)
+NEO4J_MAX_HEAP_SIZE=1g
+# Page cache size for Neo4j data caching (default: 512m)
+NEO4J_PAGE_CACHE_SIZE=512m
+
 # Grafana Configuration  
 GRAFANA_PASSWORD=contextmemory
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ graph_store:
   backup_path: "/project/graph.cypher"
 ```
 
+### Environment Variables
+
+Neo4j memory settings can be customized via environment variables:
+
+```bash
+# Neo4j Memory Configuration
+NEO4J_INITIAL_HEAP_SIZE=512m     # Initial JVM heap size
+NEO4J_MAX_HEAP_SIZE=1g           # Maximum JVM heap size  
+NEO4J_PAGE_CACHE_SIZE=512m       # Page cache for data caching
+```
+
 For detailed configuration options, see [Configuration Documentation](docs/configuration.md).
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,10 @@ services:
       - NEO4J_AUTH=none  # Authentication disabled for development ease
       - NEO4J_dbms_security_procedures_unrestricted=apoc.*
       - NEO4J_dbms_security_procedures_allowlist=apoc.*
+      # Memory Configuration (parameterized for deployment flexibility)
+      - NEO4J_server_memory_heap_initial__size=${NEO4J_INITIAL_HEAP_SIZE:-512m}
+      - NEO4J_server_memory_heap_max__size=${NEO4J_MAX_HEAP_SIZE:-1g}
+      - NEO4J_server_memory_pagecache_size=${NEO4J_PAGE_CACHE_SIZE:-512m}
     healthcheck:
       test: ["CMD", "neo4j", "status"]
       interval: 30s

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,6 +162,11 @@ export GRAPH_STORE_URI="bolt://localhost:7687"
 export GRAPH_STORE_USERNAME="neo4j"
 export GRAPH_STORE_PASSWORD="contextmemory"
 
+# Neo4j Memory Configuration
+export NEO4J_INITIAL_HEAP_SIZE="512m"
+export NEO4J_MAX_HEAP_SIZE="1g"
+export NEO4J_PAGE_CACHE_SIZE="512m"
+
 # API
 export API_HOST="0.0.0.0"
 export API_PORT="8080"

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -30,7 +30,10 @@ The Context Memory Store uses a microservices architecture with the following co
 - **Data**: Persistent volumes for data, logs, import, plugins
 - **Credentials**: Configurable via NEO4J_USERNAME/NEO4J_PASSWORD
 - **APOC Plugin**: 5.15.0-core (automatically downloaded)
-- **Memory Settings**: Default settings in use (parameterization requires Neo4j 5.15 environment variable syntax investigation)
+- **Memory Settings**: Fully parameterized via environment variables:
+  - `NEO4J_INITIAL_HEAP_SIZE` (default: 512m) - Initial JVM heap size
+  - `NEO4J_MAX_HEAP_SIZE` (default: 1g) - Maximum JVM heap size  
+  - `NEO4J_PAGE_CACHE_SIZE` (default: 512m) - Page cache for data caching
 - **APOC Configuration**: Consolidated into docker-compose.yml environment variables
 
 ### Ollama (External LLM API)

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -38,10 +38,10 @@ As of Phase 4 completion, the Context Memory Store system is functionally comple
   - Workaround: Manual metrics verification
 
 ### Infrastructure Configuration
-- **Neo4j Memory Settings** (Issue #8): Memory settings not parameterized
-  - Impact: Fixed memory allocation for all environments
-  - Planned Resolution: Future production deployment optimization
-  - Workaround: Manual Docker configuration adjustment
+- **Neo4j Memory Settings** (Issue #8): ✅ **RESOLVED** - Memory settings now fully parameterized via environment variables
+  - Status: Parameterized via `NEO4J_INITIAL_HEAP_SIZE`, `NEO4J_MAX_HEAP_SIZE`, and `NEO4J_PAGE_CACHE_SIZE`
+  - Configuration: Environment variables with sensible defaults (512m/1g/512m)
+  - Usage: Set environment variables or update `.env` file as needed
 
 ## Deferred Enhancements Timeline
 

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -167,9 +167,14 @@ curl -X POST http://localhost:7474/db/data/cypher \
 
 **Memory/Performance Issues:**
 ```bash
-# Check Neo4j memory settings in docker-compose.yml
-# Increase NEO4J_dbms_memory_heap_initial_size if needed
-# Increase NEO4J_dbms_memory_heap_max_size if needed
+# Adjust Neo4j memory settings via environment variables:
+export NEO4J_INITIAL_HEAP_SIZE=1g      # Increase initial heap
+export NEO4J_MAX_HEAP_SIZE=2g          # Increase maximum heap
+export NEO4J_PAGE_CACHE_SIZE=1g        # Increase page cache
+
+# Restart services to apply new memory settings
+docker-compose down
+docker-compose up -d neo4j
 ```
 
 ### 4. Ollama LLM Service Issues


### PR DESCRIPTION
Addresses issue #8: Enhancement - Parameterize Neo4j memory settings

Changes made:
- Added NEO4J_INITIAL_HEAP_SIZE, NEO4J_MAX_HEAP_SIZE, and NEO4J_PAGE_CACHE_SIZE environment variables to .env.example with reasonable defaults
- Modified docker-compose.yml to use parameterized memory settings with fallback defaults
- Updated comprehensive documentation in README.md, infrastructure.md, configuration.md, troubleshooting-guide.md, and known-limitations.md
- Tested both custom values and default fallback mechanism
- Verified all services continue to function correctly after changes

Benefits:
- Allows customization of Neo4j memory allocation without modifying docker-compose.yml
- Provides sensible defaults for development environments
- Enables production deployments to optimize memory usage for their specific requirements
- Maintains backward compatibility with existing deployments