### PR TITLE
Fix lifecycle endpoints documentation and clarify API routing (Fixes #136)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,11 +46,12 @@ The system uses a microservices architecture with:
 ## API Endpoints
 
 ### Core Lifecycle
-- `POST /start` - Initialize memory engine
-- `POST /stop` - Serialize memory and commit to Git
-- `GET /context` - Retrieve current memory snapshot
-- `POST /ingest` - Ingest new document or artifact
-- `GET /metrics` - Prometheus metrics endpoint
+- `POST /v1/lifecycle/start` - Initialize memory engine
+- `POST /v1/lifecycle/stop` - Serialize memory and commit to Git
+- `GET /v1/lifecycle/status` - Check current memory engine status
+- `POST /v1/memory/ingest` - Ingest new document or artifact
+- `GET /v1/memory/context` - Retrieve current memory snapshot
+- `GET /v1/metrics` - Prometheus metrics endpoint
 
 ### Interface Support
 - REST API via `/v1/...` endpoints


### PR DESCRIPTION
## Summary
- Fixed CLAUDE.md documentation to use correct endpoint paths
- The core lifecycle endpoints were already implemented and working correctly
- Updated documentation to reflect actual API paths: `/v1/lifecycle/start` and `/v1/lifecycle/stop`
- The issue was incorrect documentation, not non-functional endpoints

**Resolves #136**

## Changes Made
- Updated `CLAUDE.md` to use correct endpoint paths:
  - `POST /v1/lifecycle/start` - Initialize memory engine
  - `POST /v1/lifecycle/stop` - Serialize memory and commit to Git
  - `GET /v1/lifecycle/status` - Check current memory engine status
- Added proper `/v1/memory/` prefix for memory-related endpoints
- Clarified that endpoints were functional all along

## Testing
- ✅ Manually tested `POST /v1/lifecycle/start` - Returns 200 OK
- ✅ Manually tested `POST /v1/lifecycle/stop` - Returns 200 OK  
- ✅ Verified endpoints work correctly with proper request bodies
- ✅ Integration tests run (some failures unrelated to this fix)
- ✅ UI verification completed - Lifecycle management working through web interface

## Root Cause Analysis (Issue #136)
The issue reported 405 Method Not Allowed errors for `/v1/start` and `/v1/stop`, but the actual endpoints are:
- `/v1/lifecycle/start` ✅ (working)
- `/v1/lifecycle/stop` ✅ (working)

The documentation in CLAUDE.md was incorrect and misleading users to try the wrong endpoints.

## Impact
- **User Impact:** HIGH - Users can now find the correct endpoint paths
- **Documentation:** Updated to match actual implementation
- **API Consistency:** Maintains existing working API without breaking changes

## UI Verification
- ✅ Verified web interface lifecycle management works correctly
- ✅ "Start Engine" button successfully calls `/v1/lifecycle/start`
- ✅ Success messages displayed properly to users
- ✅ All navigation and page routing functional

Closes #136

🤖 Generated with [Claude Code](https://claude.ai/code)